### PR TITLE
[add] TitleTextBox 컴포넌트 구현

### DIFF
--- a/src/components/TitleTextBox.jsx
+++ b/src/components/TitleTextBox.jsx
@@ -1,0 +1,3 @@
+function TitleTextBox() {}
+
+export default TitleTextBox;

--- a/src/components/TitleTextBox.jsx
+++ b/src/components/TitleTextBox.jsx
@@ -1,3 +1,17 @@
-function TitleTextBox() {}
+import PropTypes from 'prop-types';
+
+function TitleTextBox({ title, sub }) {
+  return (
+    <>
+      <p className="py-[15px] mt-6 text-headline2">{title}</p>
+      <p className="text-body4">{sub}</p>
+    </>
+  );
+}
 
 export default TitleTextBox;
+
+TitleTextBox.propTypes = {
+  title: PropTypes.string.isRequired,
+  sub: PropTypes.string,
+};


### PR DESCRIPTION
## 디자인 시안

![image](https://github.com/potenday-project/promise-me-frontend/assets/74224516/f7b9664c-fe01-491c-9785-b83c3c68b3ef)

1- 타이틀 입력
2. 서브타이틀(설명 입력) 선택사항
