### PR TITLE
[modify] TitleTextBox 컴포넌트 구현

### DIFF
--- a/src/components/TitleTextBox.jsx
+++ b/src/components/TitleTextBox.jsx
@@ -3,8 +3,15 @@ import PropTypes from 'prop-types';
 function TitleTextBox({ title, sub }) {
   return (
     <>
-      <p className="py-[15px] mt-6 text-headline2">{title}</p>
-      <p className="text-body4">{sub}</p>
+      <p
+        style={{ whiteSpace: 'pre-line' }}
+        className="h-[60] mt-6 text-headline2"
+      >
+        {title}
+      </p>
+      <p style={{ whiteSpace: 'pre-line' }} className="text-body4">
+        {sub}
+      </p>
     </>
   );
 }

--- a/src/components/TitleTextBox.jsx
+++ b/src/components/TitleTextBox.jsx
@@ -9,7 +9,10 @@ function TitleTextBox({ title, sub }) {
       >
         {title}
       </p>
-      <p style={{ whiteSpace: 'pre-line' }} className="text-body4">
+      <p
+        style={{ whiteSpace: 'pre-line' }}
+        className="text-body4 -text--grey700"
+      >
         {sub}
       </p>
     </>


### PR DESCRIPTION
![image](https://github.com/potenday-project/promise-me-frontend/assets/74224516/6ce0934d-4a72-421b-92fa-30f2cc7c00a4)


두줄이 가능하도록 수정
높이값으로 고정
서브타이틀 색상 수정

사용법
![image](https://github.com/potenday-project/promise-me-frontend/assets/74224516/6888d695-df60-446d-ae53-2382b9b53c41)


\n으로 엔터